### PR TITLE
chore: remove working_dir from database service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ volumes:
 services:
   database:
     image: mariadb:11.8
-    working_dir: /var/www/html
     volumes:
       - mariadb:/var/lib/mysql:cached
     networks:


### PR DESCRIPTION
This does not work as this workdir does not exist on the container.