### PR TITLE
fix: membership status value not rendered correctly, refs #230

### DIFF
--- a/web_application/src/app/[lang]/admin/(secure)/memberships/_components/create-form.tsx
+++ b/web_application/src/app/[lang]/admin/(secure)/memberships/_components/create-form.tsx
@@ -221,7 +221,7 @@ export default function CreateForm({
                             id="status"
                             name="status"
                             label={t('membership:status.label')}
-                            defaultValue={data?.status ?? 'active'}
+                            defaultValue={data?.status}
                             options={[
                                 {
                                     value: 'active',

--- a/web_application/src/app/[lang]/admin/(secure)/memberships/_components/memberships-table.tsx
+++ b/web_application/src/app/[lang]/admin/(secure)/memberships/_components/memberships-table.tsx
@@ -141,11 +141,14 @@ export default function MembershipsTable({
                 ) : (
                     t('membership:status.label')
                 ),
-            cell: ({ row }) => (
-                <TextCell>
-                    {t(`membership:status.${row.getValue('status')}`)}
-                </TextCell>
-            ),
+            cell: ({ row }) => {
+                const status = row.getValue('status');
+                return (
+                    <TextCell>
+                        {status ? t(`membership:status.${status}`) : '-'}
+                    </TextCell>
+                );
+            },
         },
     ];
 


### PR DESCRIPTION
@larshanskrause I discovered that the form did not display the correct value. The status was in fact null and the default option for the select input was set to "active". I changed that and now the selected option will be the disabled "choose" option, if status is null.

<img width="1606" height="578" alt="vereinfacht-issue-230-membership-status-value-not-rendered-correctly-01" src="https://github.com/user-attachments/assets/9286e625-0ff2-41be-b87e-3540e7bbb1f4" />

<img width="1611" height="567" alt="vereinfacht-issue-230-membership-status-value-not-rendered-correctly-02" src="https://github.com/user-attachments/assets/636e9092-94f7-4643-8d10-f0485105a760" />


I also fixed the label for the memberships table.

<img width="1933" height="769" alt="vereinfacht-issue-230-membership-status-value-not-rendered-correctly-03" src="https://github.com/user-attachments/assets/bf41fb03-7772-4ff2-bb39-e25c4370dd3e" />
