### PR TITLE
fix: display total monthly fee in detail view, refs #229

### DIFF
--- a/web_application/src/app/[lang]/admin/(secure)/memberships/[id]/page.tsx
+++ b/web_application/src/app/[lang]/admin/(secure)/memberships/[id]/page.tsx
@@ -79,7 +79,7 @@ export default async function MembershipShowPage({ params }: Props) {
             attribute: 'monthlyFee',
             label: t('membership:monthly_fee.label'),
             type: 'currency',
-            value: membership?.membershipType?.monthlyFee,
+            value: membership?.monthlyFee,
         },
         {
             attribute: 'voluntaryContribution',


### PR DESCRIPTION
I changed it to display the computed monthly fee value, which is a total of all fees.