### PR TITLE
feat: add a button for creating another resource after creation, refs #235

### DIFF
--- a/web_application/locales/de/general.json
+++ b/web_application/locales/de/general.json
@@ -3,6 +3,7 @@
     "choose": "auswählen",
     "edit": "bearbeiten",
     "save": "speichern",
+    "save_and_create_another": "speichern und weitere erstellen",
     "cancel": "abbrechen",
     "view": "ansehen",
     "back": "zurück",

--- a/web_application/locales/en/general.json
+++ b/web_application/locales/en/general.json
@@ -3,6 +3,7 @@
     "choose": "choose",
     "edit": "edit",
     "save": "save",
+    "save_and_create_another": "save and create another",
     "cancel": "cancel",
     "view": "view",
     "back": "back",

--- a/web_application/src/app/[lang]/admin/(secure)/components/Form/ActionForm.tsx
+++ b/web_application/src/app/[lang]/admin/(secure)/components/Form/ActionForm.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import useTranslation from 'next-translate/useTranslation';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useState } from 'react';
 import CancelButton from './CancelButton';
 import FormStateHandler, { FormActionState } from './FormStateHandler';
 import SubmitButton from './SubmitButton';
+
+type RoutingOnSuccess = 'back' | 'reload';
 
 interface Props extends PropsWithChildren {
     state: FormActionState;
@@ -24,6 +26,8 @@ export default function ActionForm({
     loading = false,
 }: Props) {
     const { t } = useTranslation();
+    const [routingOnSuccess, setRoutingOnSuccess] =
+        useState<RoutingOnSuccess>('back');
 
     return (
         <form action={action} className="container flex h-full flex-col gap-8">
@@ -31,11 +35,22 @@ export default function ActionForm({
                 state={state}
                 translationKey={translationKey}
                 type={type}
+                routingOnSuccess={routingOnSuccess}
             />
             {children}
-            <div className="mt-auto flex gap-4 self-end">
+            <div className="mt-auto flex flex-wrap justify-end gap-4 self-end">
                 <CancelButton />
-                <SubmitButton title={t('general:save')} loading={loading} />
+                {type === 'create' && (
+                    <SubmitButton
+                        title={t('general:save_and_create_another')}
+                        loading={loading}
+                        onClick={() => setRoutingOnSuccess('reload')}
+                    />
+                )}
+                <SubmitButton
+                    title={t('general:save')}
+                    loading={loading}
+                />
             </div>
         </form>
     );

--- a/web_application/src/app/[lang]/admin/(secure)/components/Form/FormStateHandler.tsx
+++ b/web_application/src/app/[lang]/admin/(secure)/components/Form/FormStateHandler.tsx
@@ -52,7 +52,6 @@ export default function FormStateHandler({
                 ),
             });
 
-        
             if (onSuccess) {
                 onSuccess();
                 return;

--- a/web_application/src/app/[lang]/admin/(secure)/components/Form/FormStateHandler.tsx
+++ b/web_application/src/app/[lang]/admin/(secure)/components/Form/FormStateHandler.tsx
@@ -16,6 +16,7 @@ interface Props {
     type?: 'create' | 'update' | 'delete' | 'action';
     customNotificationTranslationKey?: string;
     onSuccess?: () => void;
+    routingOnSuccess?: 'back' | 'reload';
 }
 
 export default function FormStateHandler({
@@ -24,6 +25,7 @@ export default function FormStateHandler({
     translationKey,
     customNotificationTranslationKey,
     onSuccess,
+    routingOnSuccess = 'back',
 }: Props) {
     const { toast } = useToast();
     const { t } = useTranslation();
@@ -34,6 +36,11 @@ export default function FormStateHandler({
 
     useEffect(() => {
         if (state.success) {
+            if (routingOnSuccess === 'reload') {
+                window.location.reload();
+                return;
+            }
+
             toast({
                 variant: 'success',
                 description: t(
@@ -44,6 +51,8 @@ export default function FormStateHandler({
                     translationKey ? translationParams : { ...state },
                 ),
             });
+
+        
             if (onSuccess) {
                 onSuccess();
                 return;

--- a/web_application/src/app/[lang]/admin/(secure)/components/Form/SubmitButton.tsx
+++ b/web_application/src/app/[lang]/admin/(secure)/components/Form/SubmitButton.tsx
@@ -3,9 +3,10 @@
 import Button from '@/app/components/Button/Button';
 import { ButtonPresets } from '@/app/components/Button/presets';
 import { capitalizeFirstLetter } from '@/utils/strings';
+import { ButtonHTMLAttributes } from 'react';
 import { useFormStatus } from 'react-dom';
 
-interface Props {
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
     title: string;
     preset?: ButtonPresets;
     loading?: boolean;
@@ -15,12 +16,14 @@ export default function SubmitButton({
     title,
     preset = 'primary',
     loading,
+    ...props
 }: Props) {
     const { pending } = useFormStatus();
     const isLoading = pending || loading;
 
     return (
         <Button
+            {...props}
             type="submit"
             isLoading={isLoading}
             data-cy="submit-button"


### PR DESCRIPTION
Adds another submit button to create forms, which results in a hard reload after successful creation.

Buttons will begin to stack when the viewport is not big enough.

<img width="660" height="177" alt="vereinfacht-buttonss" src="https://github.com/user-attachments/assets/b9b85701-ddbf-4356-95f9-3d0e19d380f2" />
