### PR TITLE
fix: sometimes active state of a navigation list item is not displayed, refs 248

### DIFF
--- a/web_application/src/app/[lang]/admin/(secure)/components/Navigation/ListItem.tsx
+++ b/web_application/src/app/[lang]/admin/(secure)/components/Navigation/ListItem.tsx
@@ -12,6 +12,15 @@ export interface NavigationListItemProps {
     activeIcon?: React.ReactNode;
 }
 
+const normalizePath = (path?: string) => {
+    if (!path) return '/';
+    let cleanPath = path.split('?')[0];
+    if (cleanPath.endsWith('/') && cleanPath.length > 1) {
+        cleanPath = cleanPath.slice(0, -1);
+    }
+    return cleanPath;
+};
+
 export default function ListItem({
     title,
     href,
@@ -25,10 +34,13 @@ export default function ListItem({
         pathname,
         lang as SupportedLocale,
     );
+
+    const normalizedCurrentPath = normalizePath(unlocalizedPath);
+    const normalizedHref = normalizePath(href);
+
     const isActive = href
-        ? unlocalizedPath === href ||
-          unlocalizedPath.startsWith(href + '/') ||
-          unlocalizedPath.startsWith(href + '?')
+        ? normalizedCurrentPath === normalizedHref ||
+          normalizedCurrentPath.startsWith(normalizedHref + '/')
         : false;
 
     return (


### PR DESCRIPTION
Hi! I spent some time trying to debug the navigation list item bug. I couldn't recreate the problem on my local machine or on the production server.

The only thing I found in my research is that this usually happens right after a Next.js deployment because the client-side router cache is out of date. Once that cache cleared, the problem went away on its own.

Even though it works now, I added a small normalizePath helper function that removes trailing slashes and query parameters before comparing URLs. This should make the component more reliable in the future.

Refs #248 